### PR TITLE
Switch status from "Unofficial" to "Draft CG Report"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Title: Email Verification API
 Shortname: evp
 Level: 1
-Status: UD
+Status: CG-DRAFT
 Group: wicg
 URL: https://github.com/WICG/email-verification
 Repository: WICG/email-verification

--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <title>Email Verification API</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-  <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-UD" rel="stylesheet">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version d113b2e81, updated Tue Jun 9 14:57:55 2026 -0700" name="generator">
   <link href="https://github.com/WICG/email-verification" rel="canonical">
-  <meta content="0793d0e033ec40f70be43be30f4868bf0cd0d532" name="revision">
+  <meta content="98621b0f6a0f561d9af43da225a392bcee94a1d8" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>/* Boilerplate: style-autolinks */
@@ -719,8 +719,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
  <body class="h-entry">
   <div class="head">
    <h1 class="no-ref p-name" id="title">Email Verification API</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#UD">Unofficial Proposal Draft</a>,
-    <time class="dt-updated" datetime="2026-06-17">17 June 2026</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CG-DRAFT">Draft Community Group Report</a>,
+    <time class="dt-updated" datetime="2026-06-26">26 June 2026</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -734,7 +734,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    </div>
    <div data-fill-with="warning"></div>
    <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2026 the Contributors to the Email Verification API Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
-A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
 </p>
    <hr title="Separator for header">
   </div>
@@ -754,7 +754,7 @@ A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed
   there is a limited opt-out and other conditions apply.
 
   Learn more about
-  <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
+  <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>.
 </p>
    <p></p>
   </div>
@@ -1204,7 +1204,7 @@ Furthermore, the issuer MUST match the email domain (unless delegated explicitly
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-jwt">[JWT]
-   <dd>M. Jones; J. Bradley; N. Sakimura. <a href="https://www.rfc-editor.org/rfc/rfc7519"><cite>JSON Web Token (JWT)</cite></a>. May 2015. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7519">https://www.rfc-editor.org/rfc/rfc7519</a>
+   <dd>M. Jones; J. Bradley; N. Sakimura. <a href="https://www.rfc-editor.org/info/rfc7519/"><cite>JSON Web Token (JWT)</cite></a>. May 2015. Proposed Standard. URL: <a href="https://www.rfc-editor.org/info/rfc7519/">https://www.rfc-editor.org/info/rfc7519/</a>
    <dt id="biblio-sd-jwt">[SD-JWT]
    <dd>D. Fett; K. Yasuda; B. Campbell. <a href="https://www.rfc-editor.org/rfc/rfc9682.html"><cite>Selective Disclosure for JSON Web Tokens (SD-JWT)</cite></a>. RFC. URL: <a href="https://www.rfc-editor.org/rfc/rfc9682.html">https://www.rfc-editor.org/rfc/rfc9682.html</a>
   </dl>


### PR DESCRIPTION
This adjusts the spec status following adoption by the WICG.

FWIW, this makes it easier to integrate the spec in spec processing tools, browser-specs to start with (c.f., https://github.com/w3c/browser-specs/issues/2542).

Side note: the repository currently holds both the Bikeshed source and the generated version. Most spec repositories leverage the [`spec-prod`](https://github.com/w3c/spec-prod) action to automate the generation and publication of the HTML version. Let me know if you'd like to switch to that and need help, I'd be happy to craft a PR.