### PR TITLE
Clarify `exp` claim as optional

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -233,7 +233,7 @@ The presentation token (EVT+KB) is bound to a specific `nonce` and `audience` (v
 Verifiers MUST verify:
 1.  The `audience` matches their origin.
 2.  The `nonce` matches the one they generated for the form presentation.
-3.  The `exp` claim has not expired.
+3.  The `exp` claim, if present, has not expired.
 
 This prevents an attacker from intercepting an EVT+KB and replaying it to another site or in a different context.
 


### PR DESCRIPTION
While `exp` is optional as per https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4, it wasn't immediately clear and I think it would be helpful to be explicit as this is listed as a MUST verify.